### PR TITLE
Add `fs` dependency for prod server

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^0.13.1",
     "expose-loader": "^0.7.0",
     "file-loader": "^0.8.3",
+    "fs": "0.0.2",
     "html-webpack-plugin": "^1.4.0",
     "image-webpack-loader": "^1.4.0",
     "imagemin": "^3.2.0",


### PR DESCRIPTION
* Working local deploy of `js-nacl` breaks on prod remote server
* Cause: failure to find `fs` module
* Solution: include `fs` as dependency in package.json