### PR TITLE
Show security alert on load

### DIFF
--- a/src/app/actions/NavActions.js
+++ b/src/app/actions/NavActions.js
@@ -8,6 +8,11 @@ class NavActions extends Marty.ActionCreators {
     this.dispatch(NavConstants.PAGE_REQUESTED, page);
   }
 
+  //() -> Unit
+  alert(){
+    this.dispatch(NavConstants.SECURITY_ALERT_TRIGGERED);
+  }
+
   // () -> Unit
   toggle(){
     this.dispatch(NavConstants.NAV_TOGGLED);

--- a/src/app/actions/NavActions.js
+++ b/src/app/actions/NavActions.js
@@ -8,11 +8,6 @@ class NavActions extends Marty.ActionCreators {
     this.dispatch(NavConstants.PAGE_REQUESTED, page);
   }
 
-  //() -> Unit
-  alert(){
-    this.dispatch(NavConstants.SECURITY_ALERT_TRIGGERED);
-  }
-
   // () -> Unit
   toggle(){
     this.dispatch(NavConstants.NAV_TOGGLED);

--- a/src/app/components/Display.jsx
+++ b/src/app/components/Display.jsx
@@ -1,8 +1,9 @@
 const Marty = require('marty');
 const BaseComponent = require('./BaseComponent');
-const { HOME, MAP } = require('../constants/Pages');
+const { HOME, MAP, SEC } = require('../constants/Pages');
 const HomePage = require('./HomePage');
 const MapPage = require('./MapPage');
+const SecurityPage = require('./SecurityPage');
 const NotificationContainer = require('./NotificationContainer');
 
 class Display extends BaseComponent {
@@ -11,7 +12,8 @@ class Display extends BaseComponent {
       <div id="display">
         {{
           [HOME]: () => <HomePage ref='homePage' />,
-          [MAP]: () => <MapPage ref='mapPage' />
+          [MAP]: () => <MapPage ref='mapPage' />,
+          [SEC]: () => <SecurityPage ref='securityPage' />
          }[this.props.page]()}
         <NotificationContainer />
       </div>

--- a/src/app/components/Root.jsx
+++ b/src/app/components/Root.jsx
@@ -2,6 +2,7 @@ const Marty = require('marty');
 const BaseComponent = require('./BaseComponent.jsx');
 const Header = require('./Header.jsx');
 const Display = require('./Display.jsx');
+import { SEC } from '../constants/Pages';
 
 const sc = require('../modules/scheduler');
 const everyMinute = 60 * 1000;
@@ -27,8 +28,11 @@ Root
 class Root extends BaseComponent {
   constructor(){
     super();
-    this.state = { hasScheduled: false };
-    this.bindAll('_scheduleOnce', '_forget');
+    this.state = {
+      forgetScheduled: false,
+      securityAlerted: false
+    };
+    this.bindAll('_scheduleForget', '_forget');
   }
 
   render(){
@@ -41,19 +45,28 @@ class Root extends BaseComponent {
   };
 
   componentDidMount(){
-    this._scheduleOnce();
+    this._scheduleForget();
+    this._alertSecurity();
   }
 
-  _scheduleOnce(){
-    if (!this.state.hasScheduled) {
+  _scheduleForget(){
+    if (!this.state.forgetScheduled) {
       sc.schedule(this._forget, everyMinute);
-      this.setState({hasScheduled: true});
+      this.setState({forgetScheduled: true});
     }
   }
 
   _forget(){
     this.app.locSubActions.forget();
   }
+
+  _alertSecurity(){
+    if(!this.state.securityAlerted){
+      this.app.navActions.goto(SEC);
+      this.setState({securityAlerted: true});
+    }
+  }
+
 
 
 }

--- a/src/app/components/SecurityPage.jsx
+++ b/src/app/components/SecurityPage.jsx
@@ -1,21 +1,37 @@
 const Marty = require('marty');
 const BaseComponent = require('./BaseComponent.jsx');
 import { Button } from 'react-bootstrap';
+import { HOME } from '../constants/Pages';
 
 class SecurityPage extends BaseComponent {
+
+  constructor(){
+    super();
+    this.bindAll('_handleClick');
+  }
+
   render(){
     return (
       <div className='securityPage' ref='securityPage'>
-        <h1 className="sec-header" ref="sec-header"> THEY'RE WATCHING YOU!!! </h1>
-        <p className="sec-blurb" ref="sec-blurb">
-          We've done everything we can to ensure your anonimity while using where@. But there are some forms of surveillance we can't protect you from. We HIGHLY RECOMMEND you visit our <a href="https//about.whereat.io/stay-safe">security best practices page</a> to learn what what you can do to stay as safe as possible while using this app! :)
+        <h1 className="secHeader" ref="secHeader"> THEY'RE WATCHING YOU!!! </h1>
+        <p className="secBlurb" ref="secBlurb">
+          While we've done everything we can to ensure your anonimity while using where@, there are some forms of surveillance we can't protect you from. But not to fear! There are things you can do to protect yourself! To learn how, we HIGHLY RECOMMEND you visit our <a href="https//about.whereat.io/stay-safe">security best practices page</a>! :)
         </p>
-        <Button bsStyle="primary" ref='sec-button'>
+        <Button
+          bsStyle="primary"
+          className="secButton"
+          ref="secButton"
+          onClick={this._handleClick}
+          >
           Okay, got it!
         </Button>
       </div>
     );
   };
+
+  _handleClick(){
+    this.app.navActions.goto(HOME);
+  }
 }
 
 module.exports = Marty.createContainer(SecurityPage);

--- a/src/app/components/SecurityPage.jsx
+++ b/src/app/components/SecurityPage.jsx
@@ -1,0 +1,21 @@
+const Marty = require('marty');
+const BaseComponent = require('./BaseComponent.jsx');
+import { Button } from 'react-bootstrap';
+
+class SecurityPage extends BaseComponent {
+  render(){
+    return (
+      <div className='securityPage' ref='securityPage'>
+        <h1 className="sec-header" ref="sec-header"> THEY'RE WATCHING YOU!!! </h1>
+        <p className="sec-blurb" ref="sec-blurb">
+          We've done everything we can to ensure your anonimity while using where@. But there are some forms of surveillance we can't protect you from. We HIGHLY RECOMMEND you visit our <a href="https//about.whereat.io/stay-safe">security best practices page</a> to learn what what you can do to stay as safe as possible while using this app! :)
+        </p>
+        <Button bsStyle="primary" ref='sec-button'>
+          Okay, got it!
+        </Button>
+      </div>
+    );
+  };
+}
+
+module.exports = Marty.createContainer(SecurityPage);

--- a/src/app/components/SecurityPage.jsx
+++ b/src/app/components/SecurityPage.jsx
@@ -13,12 +13,18 @@ class SecurityPage extends BaseComponent {
   render(){
     return (
       <div className='securityPage' ref='securityPage'>
-        <h1 className="secHeader" ref="secHeader"> THEY'RE WATCHING YOU!!! </h1>
-        <p className="secBlurb" ref="secBlurb">
-          While we've done everything we can to ensure your anonimity while using where@, there are some forms of surveillance we can't protect you from. But not to fear! There are things you can do to protect yourself! To learn how, we HIGHLY RECOMMEND you visit our <a href="https//about.whereat.io/stay-safe">security best practices page</a>! :)
-        </p>
+        <h1 className="secHeader" ref="secHeader">YOU ARE BEING SPIED ON!!! </h1>
+        <div className="secBlurb" ref="secBlurb">
+          <p>
+            We've done everything we can to ensure your privacy while using where@, but there are some forms of surveillance we can't protect you from. Not to fear: you can protect yourself! To learn how, visit our <a href="https//about.whereat.io/stay-safe">security best practices page.</a>
+          </p>
+          {/* <p className="secSignature">
+              <strong><em>-- {'<3'}, where@</em></strong>
+              </p> */}
+        </div>
         <Button
           bsStyle="primary"
+          bsSize="large"
           className="secButton"
           ref="secButton"
           onClick={this._handleClick}

--- a/src/app/constants/NavConstants.js
+++ b/src/app/constants/NavConstants.js
@@ -2,6 +2,5 @@ const Marty = require('marty');
 
 module.exports = Marty.createConstants([
   'NAV_TOGGLED',
-  'PAGE_REQUESTED',
-  'SECURITY_ALERT_TRIGGERED'
+  'PAGE_REQUESTED'
 ]);

--- a/src/app/constants/NavConstants.js
+++ b/src/app/constants/NavConstants.js
@@ -1,6 +1,7 @@
 const Marty = require('marty');
 
 module.exports = Marty.createConstants([
+  'NAV_TOGGLED',
   'PAGE_REQUESTED',
-  'NAV_TOGGLED'
+  'SECURITY_ALERT_TRIGGERED'
 ]);

--- a/src/app/constants/Pages.js
+++ b/src/app/constants/Pages.js
@@ -1,4 +1,5 @@
 module.exports = {
   HOME: 'home',
-  MAP: 'map'
+  MAP: 'map',
+  SEC: 'sec'
 };

--- a/src/app/stores/NavStore.js
+++ b/src/app/stores/NavStore.js
@@ -14,7 +14,8 @@ class NavStore extends Marty.Store {
 
     this.handlers = {
       goto: NavConstants.PAGE_REQUESTED,
-      toggle: [NavConstants.NAV_TOGGLED, NavConstants.PAGE_REQUESTED]
+      hide: NavConstants.PAGE_REQUESTED,
+      toggle: NavConstants.NAV_TOGGLED
     };
   }
 
@@ -26,9 +27,15 @@ class NavStore extends Marty.Store {
   }
 
   // () -> Unit
+  hide(){
+    this.replaceState(this.state.set('expanded', false));
+  }
+
+  // () -> Unit
   toggle(){
     this.replaceState(this.state.set('expanded', !this.state.get('expanded')));
   }
+
 
   //ACCESSORS
 

--- a/src/app/stores/NavStore.js
+++ b/src/app/stores/NavStore.js
@@ -1,6 +1,6 @@
 const Marty = require('marty');
 const NavConstants = require('../constants/NavConstants');
-const { HOME, MAP } = require('../constants/Pages');
+const { HOME, MAP, SEC } = require('../constants/Pages');
 const { Map } = require('immutable');
 
 class NavStore extends Marty.Store {

--- a/src/app/styles/main.less
+++ b/src/app/styles/main.less
@@ -82,6 +82,35 @@ body {
   text-align: right;
 }
 
+// security page
+
+.securityPage {
+
+  margin: 1em;
+
+  .secHeader {
+    font-size: 2em;
+    text-decoration: blink;
+    text-align: center;
+    color: white;
+    background-color: red;
+    border-radius: .5em;
+    padding: .2em;
+  }
+  .secBlurb {
+    margin: .5em .5em 1.5em .5em;
+    text-align: justify;
+  }
+  .secSignature{
+    text-align: right;
+  }
+  .secButton {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 // go button
 
 @GO_RADIUS: 110px;

--- a/src/test/actions/NavActions.spec.js
+++ b/src/test/actions/NavActions.spec.js
@@ -36,7 +36,7 @@ describe('NavActions', () => {
 
     describe('sec', () => {
 
-      it.only("dispatched PAGE_REQUESTED 'sec'", () => {
+      it("dispatched PAGE_REQUESTED 'sec'", () => {
         const app = setup();
         app.navActions.goto(SEC);
 

--- a/src/test/actions/NavActions.spec.js
+++ b/src/test/actions/NavActions.spec.js
@@ -1,8 +1,8 @@
 const chai = require('chai');
 const Application = require('../../app/application');
 const NavConstants = require('../../app/constants/NavConstants');
-const { HOME, MAP } = require('../../app/constants/Pages');
 const { hasDispatched, createApplication } = require('marty/test-utils');
+import { HOME, MAP, SEC } from '../../app/constants/Pages';
 
 const should = chai.should();
 
@@ -34,13 +34,13 @@ describe('NavActions', () => {
       });
     });
 
-    describe('#alert', () => {
+    describe('sec', () => {
 
-      it.only('dispatches SECURITY_ALERT_TRIGGERED', () => {
+      it.only("dispatched PAGE_REQUESTED 'sec'", () => {
         const app = setup();
-        app.navActions.alert();
+        app.navActions.goto(SEC);
 
-        hasDispatched(app, NavConstants.SECURITY_ALERT_TRIGGERED).should.equal(true);
+        hasDispatched(app, NavConstants.PAGE_REQUESTED, SEC).should.equal(true);
       });
     });
 

--- a/src/test/actions/NavActions.spec.js
+++ b/src/test/actions/NavActions.spec.js
@@ -34,7 +34,17 @@ describe('NavActions', () => {
       });
     });
 
-    describe('toggle', () => {
+    describe('#alert', () => {
+
+      it.only('dispatches SECURITY_ALERT_TRIGGERED', () => {
+        const app = setup();
+        app.navActions.alert();
+
+        hasDispatched(app, NavConstants.SECURITY_ALERT_TRIGGERED).should.equal(true);
+      });
+    });
+
+    describe('#toggle', () => {
 
       it('toggles nav between expanded and collapsed states', () => {
 

--- a/src/test/components/Display.spec.js
+++ b/src/test/components/Display.spec.js
@@ -14,7 +14,7 @@ const Display = require('../../app/components/Display');
 const HomePage = require('../../app/components/HomePage');
 const MapPage = require('../../app/components/MapPage');
 const MockComponent = require('../support/mocks/MockComponent');
-const { HOME, MAP } = require('../../app/constants/Pages');
+const { HOME, MAP, SEC } = require('../../app/constants/Pages');
 
 describe('Display Component', () => {
 
@@ -62,6 +62,16 @@ describe('Display Component', () => {
 
           d.getProp('page').should.equal(MAP);
           d.mapPage.should.exist;
+        });
+      });
+
+      describe('when `page` prop is SEC', () => {
+
+        it.only('renders SecurityPage component', () => {
+          const [app, d] = setup(SEC);
+
+          d.getProp('page').should.equal(SEC);
+          d.securityPage.should.exist;
         });
       });
     });

--- a/src/test/components/Display.spec.js
+++ b/src/test/components/Display.spec.js
@@ -67,7 +67,7 @@ describe('Display Component', () => {
 
       describe('when `page` prop is SEC', () => {
 
-        it.only('renders SecurityPage component', () => {
+        it('renders SecurityPage component', () => {
           const [app, d] = setup(SEC);
 
           d.getProp('page').should.equal(SEC);

--- a/src/test/components/Root.spec.js
+++ b/src/test/components/Root.spec.js
@@ -10,31 +10,32 @@ const { createApplication } = require('marty/test-utils');
 
 const MockComponent = require('../support/mocks/MockComponent');
 const Root = require('../../app/components/Root');
+import { HOME, SEC } from '../../app/constants/Pages';
 const sc = require('../../app/modules/scheduler');
+
+import { merge } from 'lodash';
 
 
 describe('Root component', () => {
 
   const setup = (state) => {
-
     const spies = {
-      forget: sinon.spy()
+      locSub: { forget: sinon.spy() },
+      nav: { goto: sinon.spy() }
     };
-
     const app = createApplication(Application, {
-      include: ['locSubActions'],
+      include: ['locSubActions', 'navActions'],
       stub: {
-        locSubActions: spies
+        locSubActions: spies.locSub,
+        navActions: spies.nav
       }
     });
-
     const component = propTree(app);
 
-    return [app, component, spies];
+    return [app, component, merge({}, spies.locSub, spies.nav)];
   };
   const propTree = (app) =>testTree(<Root.InnerComponent />,settings(app));
   const tree = (app) => testTree(<Root />, settings(app));
-
   const settings = (app) => ({
     context: { app: app },
     stub: {
@@ -66,7 +67,7 @@ describe('Root component', () => {
       });
     });
 
-    describe('_#scheduleOnce', () => {
+    describe('_#scheduleForget', () => {
 
       it('schedules forgetting once and only once', () => {
 
@@ -79,8 +80,21 @@ describe('Root component', () => {
           60 * 1000
         );
 
-        comp.element._scheduleOnce();
+        comp.element._scheduleForget();
         schedule.should.have.callCount(1);
+      });
+    });
+
+    describe('#_alertSecurity', () => {
+
+      it.only('shows security alert once and only once on load', () => {
+
+        const [app, comp, {goto} ] = setup();
+
+        goto.should.have.been.calledWith(SEC);
+
+        comp.element._alertSecurity();
+        goto.should.have.callCount(1);
       });
     });
   });

--- a/src/test/components/Root.spec.js
+++ b/src/test/components/Root.spec.js
@@ -53,7 +53,7 @@ describe('Root component', () => {
     });
   });
 
-  describe.only('events', () => {
+  describe('events', () => {
 
     describe('#_forget', () =>{
 

--- a/src/test/components/Root.spec.js
+++ b/src/test/components/Root.spec.js
@@ -87,7 +87,7 @@ describe('Root component', () => {
 
     describe('#_alertSecurity', () => {
 
-      it.only('shows security alert once and only once on load', () => {
+      it('shows security alert once and only once on load', () => {
 
         const [app, comp, {goto} ] = setup();
 

--- a/src/test/components/SecurityPage.spec.js
+++ b/src/test/components/SecurityPage.spec.js
@@ -1,0 +1,56 @@
+const sinon = require('sinon');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const should = chai.should();
+
+const Application = require('../../app/application');
+const { createApplication } = require('marty/test-utils');
+const testTree = require('react-test-tree');
+import { HOME } from '../../app/constants/Pages';
+
+const SecurityPage = require('../../app/components/SecurityPage');
+
+describe('SecurityPage component', () => {
+
+  const setup = () => {
+    const spies = {goto: sinon.spy()};
+    const app = createApplication(Application, { stub: { navActions: spies }});
+    const comp = propTree(app);
+    return [app, comp, spies];
+  };
+
+  const propTree = (app, color) => (
+    testTree(<SecurityPage.InnerComponent />, settings(app)));
+  const tree = (app) => testTree(<SecurityPage />, settings(app));
+  const settings = (app) => ({context: { app: app }});
+
+  describe('contents', () => {
+
+    it('renders correct HTML elements', () => {
+
+      const [_, sp] = setup();
+
+      sp.secHeader.should.exist;
+      sp.secHeader.getClassName().should.equal('secHeader');
+      sp.secBlurb.should.exist;
+      sp.secBlurb.getClassName().should.equal('secBlurb');
+      sp.secButton.should.exist;
+      sp.secButton.getClassName().should.equal('secButton btn btn-primary');
+    });
+  });
+
+  describe('events', () => {
+
+    describe('clicking dismissal button', () => {
+
+      it('calls `navActions.goto(HOME)`', () => {
+
+        const[app, sp, {goto}] = setup();
+        sp.secButton.click();
+
+        goto.should.have.been.calledWith(HOME);
+      });
+    });
+  });
+});

--- a/src/test/stores/NavStore.spec.js
+++ b/src/test/stores/NavStore.spec.js
@@ -79,41 +79,66 @@ describe('NavStore', () => {
       });
     });
 
+    describe('#hide', () => {
+
+      it('handles PAGE_REQUESTED', () => {
+        const [app] = setup();
+        const hide = sinon.spy(app.navStore, 'hide');
+        dispatch(app, NavConstants.PAGE_REQUESTED, HOME);
+
+        hide.should.have.been.calledOnce;
+      });
+
+      it('sets state.expanded to false', () => {
+        const[app] = setup(HOME);
+        app.navStore.state.set('expanded', true);
+        app.navStore.hide();
+
+        app.navStore.state.get('expanded').should.equal(false);
+      });
+
+      it('notifies listeners of state change', () => {
+        const [app, listener] = setup(HOME);
+        app.navStore.replaceState(app.navStore.state.set('expanded', true));
+        app.navStore.hide();
+
+        shouldHaveBeenCalledNthTimeWithImmutable(
+          listener, 1, Map({ page: HOME, expanded: false })
+        );
+      });
+    });
+
     describe('#toggle()', () => {
 
+      it('handles NAV_TOGGLED', () => {
+        const [app] = setup(HOME);
+        const toggle = sinon.spy(app.navStore, 'toggle');
+        dispatch(app, NavConstants.NAV_TOGGLED);
+
+        toggle.should.have.been.calledOnce;
+      });
+
       it('toggles `expanded` btw true and false', () => {
-        const [app, listener] = setup(HOME);
+        const [app] = setup(HOME);
         app.navStore.state.get('expanded').should.equal(false);
 
-        dispatch(app, NavConstants.NAV_TOGGLED);
+        app.navStore.toggle();
         app.navStore.state.get('expanded').should.equal(true);
 
-        dispatch(app, NavConstants.NAV_TOGGLED);
+        app.navStore.toggle();
         app.navStore.state.get('expanded').should.equal(false);
       });
 
       it('notifies listers of state change', () => {
         const [app, listener] = setup(HOME);
 
-        dispatch(app, NavConstants.NAV_TOGGLED);
-        //listener.should.have.been.calledWith(Map({ page: HOME, expanded: true}));
+        app.navStore.toggle();
+        shouldHaveBeenCalledNthTimeWithImmutable(
+          listener, 0, Map({ page: HOME, expanded: true }));
 
-        dispatch(app, NavConstants.NAV_TOGGLED);
-        //listener.should.have.been.calledWith(Map({ page: HOME, expanded: false }));
-        listener.should.have.been.calledTwice;
-
-      });
-
-      it('responds to both NAV_TOGGLED and PAGE_SELECTED', () => {
-        const [app, listener] = setup(HOME);
-
-        dispatch(app, NavConstants.NAV_TOGGLED);
-        app.navStore.state.get('expanded').should.equal(true);
-
-        dispatch(app, NavConstants.PAGE_REQUESTED);
-        app.navStore.state.get('expanded').should.equal(false);
-
-        listener.should.have.been.calledTwice;
+        app.navStore.toggle();
+        shouldHaveBeenCalledNthTimeWithImmutable(
+          listener, 1, Map({ page: HOME, expanded: false }));
       });
     });
   });

--- a/src/test/stores/NavStore.spec.js
+++ b/src/test/stores/NavStore.spec.js
@@ -62,7 +62,7 @@ describe('NavStore', () => {
         app.navStore.state.get('page').should.equal(SEC);
       });
 
-      it.only('notifies listener of state change', () => {
+      it('notifies listener of state change', () => {
         const [app, listener] = setup(MAP);
 
         app.navStore.goto(HOME);

--- a/src/test/support/matchers.js
+++ b/src/test/support/matchers.js
@@ -18,4 +18,8 @@ matchers.shouldHaveObjectEquality = (obj1, obj2) => (
 matchers.shouldHaveBeenCalledWithImmutable = (listener, state) => (
   listener.getCall(0).args[0].equals(state).should.equal(true));
 
+
+matchers.shouldHaveBeenCalledNthTimeWithImmutable = (listener, n, state) => (
+  listener.getCall(n).args[0].equals(state).should.equal(true));
+
 module.exports = matchers;


### PR DESCRIPTION
User Story:
* When user loads app for the fist time, they see an alert page linking to a security best practices page on about.whereat.io

Implementation:
* add an `_alertSecurity` method to `Root` component, fires once and once only on first render, calls `NavActions#goto(SEC)`
* add `SecurityPage` component: looks scary, links to best practices, clicking "Okay, got it" navigates to home page
* add ability to render `SecurityPage` component as child to `Display` component
* add logic for setting `SecurityPage` as current page to `NavActions` and `NavStore`
* clean up buggy logic for toggling/hiding nav dropdown turned up through implementing this story