### PR TITLE
Two button security alert page

### DIFF
--- a/src/app/components/SecurityPage.jsx
+++ b/src/app/components/SecurityPage.jsx
@@ -13,21 +13,40 @@ class SecurityPage extends BaseComponent {
   render(){
     return (
       <div className='securityPage' ref='securityPage'>
-        <h1 className="secHeader" ref="secHeader">YOU ARE BEING SPIED ON!!! </h1>
+
+        <h1 className="secHeader" ref="secHeader">YOU'RE BEING SPIED ON!!! </h1>
+
         <div className="secBlurb" ref="secBlurb">
           <p>
-            We've done everything we can to ensure your privacy while using where@, but there are some forms of surveillance we can't protect you from. Not to fear: you can protect yourself! To learn how, visit our <a ref="staySafeLink" href="https://about.whereat.io/stay-safe">security best practices page.</a>
+            We've done everything we can to ensure your privacy while using where@, but there are some forms of surveillance we can't protect you from. Not to fear: you can protect yourself! To learn how, visit our security best practices page.
           </p>
         </div>
-        <Button
-          bsStyle="primary"
-          bsSize="large"
-          className="secButton"
-          ref="secButton"
-          onClick={this._handleClick}
-          >
-          Okay, got it!
-        </Button>
+
+        <div ref="secButtons" className="secButtons" >
+
+          <Button
+            bsStyle="primary"
+            bsSize="large"
+            className="secButton secNoButton"
+            ref="secNoButton"
+            onClick={this._handleClick}
+            >
+            Stay exposed
+          </Button>
+
+          <Button
+            bsStyle="primary"
+            bsSize="large"
+            className="secButton secYesButton"
+            ref="secYesButton"
+            >
+            <a ref="staySafeLink" href="https://about.whereat.io/stay-safe">
+              Get protection
+            </a>
+          </Button>
+
+        </div>
+
       </div>
     );
   };

--- a/src/app/styles/main.less
+++ b/src/app/styles/main.less
@@ -32,6 +32,10 @@ body {
   visibility: visible;
 }
 
+.shadowed {
+  text-shadow: .05em .05em black;
+}
+
 // header
 
 .navbar {
@@ -68,7 +72,7 @@ body {
 
   //text
   text-align: center;
-  text-shadow: .05em .05em black;
+  .shadowed;
 }
 
 // display
@@ -93,25 +97,38 @@ body {
   margin: 1em;
 
   .secHeader {
-    font-size: 2em;
-    text-decoration: blink;
+    font-size: 1.5em;
     text-align: center;
     color: white;
     background-color: @RED;
-    border-radius: .5em;
-    padding: .2em;
+    border-radius: .25em;
+    padding: 5% .2em 5% .2em;
+    height: 50%;
+    .shadowed;
   }
   .secBlurb {
     margin: .5em .5em 1.5em .5em;
+    font-size: .9em;
     text-align: justify;
   }
-  .secSignature{
-    text-align: right;
-  }
   .secButton {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
+    font-size: .8em;
+    margin-left: .5em;
+    margin-right: .5em;
+    border: 0;
+    width: 44%;
+    text-align: center;
+  }
+  .secNoButton {
+    float: left;
+    background-color: @RED;
+  }
+  .secYesButton {
+    background-color: @GREEN;
+    float: right;
+    a {
+      color: white;
+    }
   }
 }
 

--- a/src/app/styles/main.less
+++ b/src/app/styles/main.less
@@ -97,14 +97,15 @@ body {
   margin: 1em;
 
   .secHeader {
-    font-size: 1.5em;
+    font-size: 1.2em;
+    font-weight: bold;
     text-align: center;
-    color: white;
     background-color: @RED;
     border-radius: .25em;
     padding: 5% .2em 5% .2em;
     height: 50%;
     .shadowed;
+    .btn-danger;
   }
   .secBlurb {
     margin: .5em .5em 1.5em .5em;
@@ -117,14 +118,16 @@ body {
     margin-right: .5em;
     border: 0;
     width: 44%;
+    font-weight: bold;
     text-align: center;
   }
   .secNoButton {
     float: left;
-    background-color: @RED;
+    //background-color: @RED;
+    .btn-danger;
   }
   .secYesButton {
-    background-color: @GREEN;
+    .btn-success;
     float: right;
     a {
       color: white;

--- a/src/test/components/SecurityPage.spec.js
+++ b/src/test/components/SecurityPage.spec.js
@@ -33,10 +33,18 @@ describe('SecurityPage component', () => {
 
       sp.secHeader.should.exist;
       sp.secHeader.getClassName().should.equal('secHeader');
+
       sp.secBlurb.should.exist;
       sp.secBlurb.getClassName().should.equal('secBlurb');
-      sp.secButton.should.exist;
-      sp.secButton.getClassName().should.equal('secButton btn btn-lg btn-primary');
+
+      sp.secNoButton.should.exist;
+      sp.secNoButton.getClassName()
+        .should.equal('secButton secNoButton btn btn-lg btn-primary');
+
+      sp.secYesButton.should.exist;
+      sp.secYesButton.getClassName()
+        .should.equal('secButton secYesButton btn btn-lg btn-primary');
+
       sp.staySafeLink.should.exist;
       sp.staySafeLink.getAttribute('href').should.equal('https://about.whereat.io/stay-safe');
     });


### PR DESCRIPTION
User story:
========
* Security Alert page has a "yes" button that links to a best practices page and a "no" button that enters the app (Used to only have a no button and a link embedded in the page's text)

Screenshot:
=========
<img width=50% alt="twobuttonsecurityalert" src="https://cloud.githubusercontent.com/assets/6032844/10740978/b1800f6a-7bfb-11e5-855c-97bd92d14c42.png">


Implementation
=============
* remove link from blurb
* add yes/no buttons with green/red backgrounds
* clicking yes button links to about.whereat.io/stay-safe
* tweak styles to make them prettier